### PR TITLE
Add git credential manager to brewfile

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -17,6 +17,7 @@ brew "go"
 brew "rust"
 
 # Applications
+cask "git-credential-manager"
 cask "iterm2"
 cask "google-chrome"
 cask "visual-studio-code"


### PR DESCRIPTION
Using refined tokens is a new requirement from github, and the git-credential-manager takes care of it for us